### PR TITLE
AuthenticatedUser Generator

### DIFF
--- a/invenio_config_tugraz/generators.py
+++ b/invenio_config_tugraz/generators.py
@@ -153,7 +153,7 @@ The succinct encoding of the permissions for your instance gives you
 
 from elasticsearch_dsl.query import Q
 from flask import current_app, request
-from invenio_access.permissions import any_user, superuser_access
+from invenio_access.permissions import any_user, authenticated_user, superuser_access
 from invenio_records_permissions.generators import Generator
 
 
@@ -221,3 +221,20 @@ class RecordIp(Generator):
         if user_ip in current_app.config["INVENIO_CONFIG_TUGRAZ_SINGLE_IP"]:
             return True
         return False
+
+
+class AuthenticatedUser(Generator):
+    """Allows authenticated users."""
+
+    def __init__(self):
+        """Constructor."""
+        super(AuthenticatedUser, self).__init__()
+
+    def needs(self, **kwargs):
+        """Enabling Needs."""
+        return [authenticated_user]
+
+    def query_filter(self, **kwargs):
+        """Filters for current identity as super user."""
+        # TODO: Implement with new permissions metadata
+        return []

--- a/invenio_config_tugraz/rdm_permissions.py
+++ b/invenio_config_tugraz/rdm_permissions.py
@@ -64,7 +64,7 @@ from invenio_records_permissions.generators import (
     SuperUser,
 )
 
-from .generators import RecordIp
+from .generators import AuthenticatedUser, RecordIp
 
 
 class TUGRAZPermissionPolicy(RDMRecordPermissionPolicy):
@@ -81,9 +81,8 @@ class TUGRAZPermissionPolicy(RDMRecordPermissionPolicy):
     # RecordIp: grant access for single_ip
     # RecordOwners: owner of records, enable once the deposit is allowed only for loged-in users.
     # CURRENT:
-    # AnyUser
     # RecordIp: grant access for single_ip
-    can_read = [AnyUser(), RecordIp()]  # RecordOwners()
+    can_read = [RecordIp()]  # RecordOwners()
 
     # Search access given to:
     # AnyUser : grant access anyUser
@@ -96,11 +95,10 @@ class TUGRAZPermissionPolicy(RDMRecordPermissionPolicy):
     # Delete access given to admins only.
     can_delete = [Admin()]
 
-    # TODO: create (AuthenticatedUser) generator
     # Create action given to AuthenticatedUser
     # UI - if user is loged in
-    # API - if user has be Access token (Bearer API-TOKEN)
-    # can_create = [AuthenticatedUser()]
+    # API - if user has Access token (Bearer API-TOKEN)
+    can_create = [AuthenticatedUser()]
 
     # Associated files permissions (which are really bucket permissions)
     # can_read_files = [AnyUserIfPublic(), RecordOwners()]

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -8,9 +8,9 @@
 
 """Test Generators."""
 
-from invenio_access.permissions import any_user
+from invenio_access.permissions import any_user, authenticated_user
 
-from invenio_config_tugraz.generators import RecordIp
+from invenio_config_tugraz.generators import AuthenticatedUser, RecordIp
 
 
 def test_recordip(create_app, open_record, singleip_record):
@@ -27,3 +27,12 @@ def test_recordip(create_app, open_record, singleip_record):
     assert generator.excludes(record=open_record) == []
 
     assert generator.query_filter().to_dict() == {'bool': {'must_not': [{'match': {'access.access_right': 'singleip'}}]}}
+
+
+def test_authenticateduser():
+    """Test Generator AuthenticatedUser."""
+    generator = AuthenticatedUser()
+
+    assert generator.needs() == [authenticated_user]
+    assert generator.excludes() == []
+    assert generator.query_filter() == []


### PR DESCRIPTION
## AuthenticatedUser Generator
### AIM 
Implement a Generator (AuthenticatedUser), which will be used to create records - ```can_create```
* API - only users with access token should be able to create a record.
* UI - only authenticated (logged in) users should be able to create a record. 

###  Create a new record with ```Access Token```
```
curl -k -XPOST -H "Authorization: Bearer <your token>" -H "Content-Type: application/json" https://127.0.0.1:5000/api/records -d '{
    "access": {
        "access_right": "open",
        "files": false,
        "owned_by": [1],
        "metadata": false,
        "embargo_date": "2021-02-15"
    },
    "metadata": {
        "creators": [
            {
                "name": "Marcus Junius Brutus",
                "type": "personal",
                "given_name": "Marcus",
                "family_name": "Brutus",
                "identifiers": {
                    "orcid": "0000-0002-1825-0097"
                },
                "affiliations": [
                    {
                        "name": "Entity One",
                        "identifiers": {
                            "ror": "02ex6cf31"
                        }
                    }
                ]
            }
        ],
        "description": "A story about how permissions work.",
        "rights": [
            {
                "rights": "Berkeley Software Distribution 3",
                "uri": "https://opensource.org/licenses/BSD-3-Clause",
                "identifier": "BSD-3",
                "scheme": "BSD-3"
            }
        ],
        "publication_date": "2020-08-31",
        "resource_type": {
            "type": "image",
            "subtype": "image-photo"
        },
        "title": "A permission story",
        "version": "v0.0.1"
}
}'
```
### Publish the record
```
curl -k -XPOST "Content-Type: application/json" https://127.0.0.1:5000/api/records/47887-4d639/draft/actions/publish
```
