### PR TITLE
refactor configs

### DIFF
--- a/invenio_config_tugraz/config.py
+++ b/invenio_config_tugraz/config.py
@@ -39,6 +39,7 @@ APP_ALLOWED_HOSTS = [
     "127.0.0.1",
     "invenio-dev01.tugraz.at",
     "invenio-test.tugraz.at",
+    "repository.tugraz.at"
 ]
 """Allowed Hosts"""
 
@@ -201,9 +202,9 @@ RECAPTCHA_PRIVATE_KEY = None
 # )
 #
 # Uncomment these to enable overriding RDM permissions
-RDM_RECORDS_BIBLIOGRAPHIC_SERVICE_CONFIG = (
-    'invenio_config_tugraz.rdm_permissions.TUGRAZBibliographicRecordServiceConfig'
-)
+# RDM_RECORDS_BIBLIOGRAPHIC_SERVICE_CONFIG = (
+#     'invenio_config_tugraz.rdm_permissions.TUGRAZBibliographicRecordServiceConfig'
+# )
 """Access control configuration for records."""
 
 # invenio-rdm-records


### PR DESCRIPTION
feature: adding the domain to allowed host
refactor: disabled RDM permission override from module initial - will be used based on env.
*Reason- for disabling the override configuration in the module was to have control on activating and deactivating it outside of the module such as using ```invenio.cfg```.*

This closes #40