### PR TITLE
ci(publish): ping babel version

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel babel
+          pip install setuptools wheel "babel<=2.9.1"
       - name: Build package
         run: |
           python setup.py compile_catalog sdist bdist_wheel


### PR DESCRIPTION
with the release of `2.10.*` the compile_catalog does not actually compile.
for a quick fix, we restrict the version until `2.9.1`