### PR TITLE
setup: add support for python3.11 and 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020-2023 Graz University of Technology.
+# Copyright (C) 2020-2024 Graz University of Technology.
 #
 # invenio-config-tugraz is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -27,6 +27,8 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Development Status :: 3 - Alpha
 
 [options]
@@ -42,9 +44,10 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0
-    pytest-invenio>=2.1.0,<3.0.0
+    invenio-app>=1.5.0
     invenio-search[opensearch2]>=2.1.0,<3.0.0
+    pytest-black-ng>=0.4.0
+    pytest-invenio>=2.1.0,<3.0.0
     Sphinx>=4.5.0
 
 [options.entry_points]


### PR DESCRIPTION
* pytest-black -> pytest-black-ng, former unsupported

* add invenio-app to test install requires
