### PR TITLE
permissions: Add curation moderators to RDM record policy

### DIFF
--- a/invenio_config_tugraz/permissions/policies.py
+++ b/invenio_config_tugraz/permissions/policies.py
@@ -28,6 +28,10 @@ is verified at the moment it is undertaken.
 
 from invenio_administration.generators import Administration
 from invenio_communities.generators import CommunityCurators
+from invenio_curations.services.generators import (
+    CurationModerators,
+    IfCurationRequestExists,
+)
 from invenio_rdm_records.services.generators import (
     AccessGrant,
     CommunityInclusionReviewers,
@@ -80,6 +84,9 @@ class TUGrazRDMRecordPermissionPolicy(RecordPermissionPolicy):
         SecretLinks("preview"),
         SubmissionReviewer(),
         UserManager,
+        # Allow curation moderators to access a record, if a request for the record exists.
+        # Since we set all other permission in this policy as well, this only has to be specified here.
+        IfCurationRequestExists(then_=[CurationModerators()], else_=[]),
     ]
     can_view = can_preview + [
         AccessGrant("view"),

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ python_requires = >=3.12
 zip_safe = False
 install_requires =
     invenio-cache>=1.1.1
+    invenio-curations>=0.1.0
     invenio-i18n>=2.0.0
     invenio-rdm-records>=4.0.0
 


### PR DESCRIPTION
Allow RDM record curators to preview records, if a draft exists.
As all permissions are set in the policy, only the `can_preview` has to be set. Other permissions use the `can_view` or `can_read` which in turn use `can_preview`, so curator access trickles down.