### PR TITLE
feat: custom vocab transformer for ROR funders

### DIFF
--- a/invenio_config_tugraz/config.py
+++ b/invenio_config_tugraz/config.py
@@ -390,3 +390,6 @@ CONFIG_TUGRAZ_OAUTH_EXTERNAL_ID_ATTRIBUTE = ""
 
 CONFIG_TUGRAZ_OAUTH_USERNAME_PREFIX = "idp"
 """Prefix the username with this value if CONFIG_TUGRAZ_OAUTH_USERNAME_ATTRIBUTE is set."""
+
+CONFIG_TUGRAZ_ROR_FUNDERS_NAME_CONTAINS = ["austrian", "european"]
+"""List of strings that should be included in the ROR funder name for TU Graz custom vocabulary transformer."""

--- a/invenio_config_tugraz/datastreams.py
+++ b/invenio_config_tugraz/datastreams.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 Graz University of Technology.
+#
+# invenio-config-tugraz is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Custom TU Graz datastreams."""
+
+from typing import Any
+
+from flask import current_app
+from invenio_vocabularies.contrib.funders.datastreams import FundersRORTransformer
+from invenio_vocabularies.datastreams.datastreams import StreamEntry
+from invenio_vocabularies.datastreams.errors import TransformerError
+
+
+class TuGrazRORTransformer(FundersRORTransformer):
+    """Custom TU Graz ROR Datastream transformer."""
+
+    def apply(
+        self,
+        stream_entry: StreamEntry,
+        **kwargs: Any,  # noqa: ANN401
+    ) -> StreamEntry:
+        """Apply the transformation to the stream entry.
+
+        Apply the default transformation then filter based on TU Graz repository
+        requirements. Current requirements:
+        - funder must be an Austrian funder
+        - funder must be an EU funder
+        """
+        stream_entry = super().apply(stream_entry, **kwargs)
+        ror = stream_entry.entry
+
+        if not (
+            ror["country"] == "AT"
+            or ror["country_name"] == "Austria"
+            or any(
+                funder_partial_name in ror["name"].lower()
+                for funder_partial_name in current_app.config.get(
+                    "CONFIG_TUGRAZ_ROR_FUNDERS_NAME_CONTAINS",
+                )
+            )
+        ):
+            msg = "ROR Entry not needed for TU Graz Repository."
+            raise TransformerError(msg)
+
+        return stream_entry


### PR DESCRIPTION
  * filter ROR funders for Austrian and EU specifics

to use this, invenio.cfg needs:

```
from invenio_vocabularies.config import VOCABULARIES_DATASTREAM_TRANSFORMERS
from invenio_config_tugraz.datastreams import TuGrazRORTransformer

VOCABULARIES_DATASTREAM_TRANSFORMERS = {
    **VOCABULARIES_DATASTREAM_TRANSFORMERS,
    "tug-ror-funders": TuGrazRORTransformer,
}
```

Then, in admin interface, create a Job with the task `Load ROR funders`, and change the custom arguments to use `tug-ror-funders` transformer.

